### PR TITLE
preventScroll fix

### DIFF
--- a/src/lib/action/focus.ts
+++ b/src/lib/action/focus.ts
@@ -547,7 +547,7 @@ export function focus(trap: HTMLElement, opts: FocusOptions | boolean): FocusAct
 		assignAriaHidden = !!opts?.assignAriaHidden;
 		focusable = !!opts.focusable;
 		element = opts.element;
-		let { focusDelay, delay } = opts;
+		let { focusDelay, delay, preventScroll } = opts;
 
 		if (typeof focusDelay === "number") {
 			const ms = focusDelay;
@@ -573,6 +573,7 @@ export function focus(trap: HTMLElement, opts: FocusOptions | boolean): FocusAct
 			element,
 			focusDelay,
 			delay,
+            		preventScroll,
 		};
 		if (!enabled) {
 			return destroy();


### PR DESCRIPTION
Bugfix. 
Field `preventScroll` simply was not exist in the `options` object. 
I added this field, now everything works correctly.